### PR TITLE
Increase watchdog time limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ var gh = new Octokit({
 async function main() {
     const prs = await recentPrs()
     const longestLatency = recentPackages(prs)
-    if (longestLatency > 3600) {
-        console.log("types-publisher's longest unpublished latency was over 1 hour.");
+    if (longestLatency > 5400) {
+        console.log("types-publisher's longest unpublished latency was over 1.5 hour.");
         throw new Error();
     }
 }


### PR DESCRIPTION
Publication now happens every 30 minutes, so increase the time limit to 1.5 hours.